### PR TITLE
Adding visvor option to the plugin

### DIFF
--- a/aiida_zeopp/data/parameters.py
+++ b/aiida_zeopp/data/parameters.py
@@ -148,11 +148,11 @@ class NetworkParameters(Dict):
             if k in list(output_options.keys()):
                 v = output_options[k][1]
                 if len(v) > 1:
-                    for i in enumerate(v):
+                    for index, item in enumerate(v):
                         output_dict.update({
-                            k + str(i + 1):
+                            k + str(index + 1):
                             self._OUTPUT_FILE_PREFIX.format(k + "." +
-                                                            str(v[i]))
+                                                            str(item))
                         })
                 else:
                     output_dict.update({k: self._OUTPUT_FILE_PREFIX.format(k)})

--- a/aiida_zeopp/data/parameters.py
+++ b/aiida_zeopp/data/parameters.py
@@ -126,6 +126,8 @@ class NetworkParameters(Dict):
             # add output file name
             if (k in output_keys) and (k != 'visVoro'):
                 parameter += [self._OUTPUT_FILE_PREFIX.format(k)]
+            elif k.startswith('visVoro'):
+                parameter += [self._OUTPUT_FILE_PREFIX.format('visVoro')]
 
             parameters += parameter
 
@@ -148,9 +150,9 @@ class NetworkParameters(Dict):
                     d.update({k: self._OUTPUT_FILE_PREFIX.format(k)})
                 elif k == 'visVoro':
                     d.update({
-                        'visVoro_allnodes' : 'HKUST-1' + '_voro.xyz',
-                        'visVoro_accnodes' : 'HKUST-1' + '_voro_accessible.xyz',
-                        'visVoro_nonaccnodes' : 'HKUST-1' + '_voro_nonaccessible.xyz',
+                        'visVoro_allnodes' : self._OUTPUT_FILE_PREFIX.format(k) + '_voro.xyz',
+                        'visVoro_accnodes' : self._OUTPUT_FILE_PREFIX.format(k) + '_voro_accessible.xyz',
+                        'visVoro_nonaccnodes' : self._OUTPUT_FILE_PREFIX.format(k) + '_voro_nonaccessible.xyz',
                     })
         return d
 

--- a/aiida_zeopp/parsers/network.py
+++ b/aiida_zeopp/parsers/network.py
@@ -61,11 +61,11 @@ class NetworkParser(Parser):
 
             with self.retrieved.open(fname, 'rb') as handle:
                 if parser is None:
-                    
+
                     # just add file, if no parser implemented
                     parsed = SinglefileData(file=handle)
                     self.out(link, parsed)
-                    
+
                     # workaround: if block pocket file is empty, raise an error
                     # (it indicates the calculation did not finish)
                     if link == 'block':
@@ -75,8 +75,6 @@ class NetworkParser(Parser):
                             )
                             empty_block = True
 
-
-                            
                 else:
                     # else parse and add keys to output_parameters
                     try:

--- a/setup.json
+++ b/setup.json
@@ -48,8 +48,8 @@
         "pre-commit": [
             "pre-commit==1.11.0",
             "yapf==0.26.0",
-            "prospector==0.12.11",
-            "pylint==1.9.4"
+            "prospector==1.1.6.2",
+            "pylint==2.2.1"
         ]
     }
 }


### PR DESCRIPTION
These changes made the plugin able to deal with the `visVoro` option of `zeo++` code. This option generates six output files three `xyz` and three `vtk`. Since, we only need the coordinates of Voronoi nodes for further calculations, I just modified the plugin to deal with `xyz` files and retrieve them. 