### PR TITLE
Fix psd nan

### DIFF
--- a/aiida_zeopp/parsers/plain.py
+++ b/aiida_zeopp/parsers/plain.py
@@ -246,6 +246,10 @@ class PoresSizeDistParser(object):
         results: dict
             dictionary of output values
         """
+        def isnan(numstr):
+            """Returns True if numstr is 'nan' or '-nan' and False for any other numerical string value."""
+            return float(numstr) != float(numstr)
+
         lines = string.splitlines()
         # remove empty lines
         lines = [l for l in lines if l.strip()]
@@ -264,8 +268,9 @@ class PoresSizeDistParser(object):
             bin, count, cumulative, derivative = line.split()  # pylint: disable=redefined-builtin
             bins.append(float(bin))
             counts.append(int(count))
-            cumulatives.append(float(cumulative))
-            derivatives.append(float(derivative))
+            # Append 0 if Zeo++ is printing nan/-nan: this happens when all the count values are zero
+            cumulatives.append([float(cumulative), 0][isnan(cumulative)])
+            derivatives.append([float(derivative), 0][isnan(derivative)])
 
         psd_dict = {
             'psd': {

--- a/examples/example_02.py
+++ b/examples/example_02.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Submit a zeo++ test calculation."""
+# pylint: disable=invalid-name
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import click
+from aiida import cmdline
+
+
+def test_submit(network_code):
+    """Example of how to submit a zeo++ calculation.
+
+    Simply copy the contents of this function into a script.
+    """
+    from aiida.plugins import DataFactory, CalculationFactory
+    from aiida.engine import run_get_node
+
+    if not network_code:
+        from aiida_zeopp import tests
+        network_code = tests.get_code(entry_point='zeopp.network')
+
+    # Prepare input parameters
+    NetworkParameters = DataFactory('zeopp.parameters')
+    # For allowed keys, print(NetworkParameters.schema)
+    parameters = NetworkParameters(
+        dict={
+            'ha': 'DEF',  #just for speed; use 'DEF' for prodution!
+            'psd': [1.2, 1.2, 1000],  #compute pore size distribution
+        })
+
+    CifData = DataFactory('cif')
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    structure = CifData(file=os.path.join(this_dir, 'HKUST-1.cif'))
+
+    # set up calculation
+    inputs = {
+        'code': network_code,
+        'parameters': parameters,
+        'structure': structure,
+        'metadata': {
+            'options': {
+                'max_wallclock_seconds': 1 * 60,
+            },
+            'label': 'aiida_zeopp example calculation',
+            'description': 'Compute PSD',
+        },
+    }
+
+    NetworkCalculation = CalculationFactory('zeopp.network')
+    print('Running NetworkCalculation: computing PSD ...')
+    result, node = run_get_node(NetworkCalculation,
+                                **inputs)  # or use aiida.engine.submit
+
+    print('NetworkCalculation<{}> terminated.'.format(node.pk))
+
+    print('\nComputed output_parameters {}\n'.format(
+        str(result['output_parameters'])))
+
+
+@click.command()
+@cmdline.utils.decorators.with_dbenv()
+@cmdline.params.options.CODE()
+def cli(code):
+    """Run example.
+
+    Example usage: $ ./example_02.py --code network@localhost
+
+    Alternative (creates network@localhost-test code): $ ./example_02.py
+
+    Help: $ ./example_02.py --help
+    """
+    test_submit(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/example_03.py
+++ b/examples/example_03.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Submit a zeo++ test calculation."""
+# pylint: disable=invalid-name
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import click
+from aiida import cmdline
+
+
+def test_submit(network_code):
+    """Example of how to submit a zeo++ calculation.
+
+    Simply copy the contents of this function into a script.
+    """
+    from aiida.plugins import DataFactory, CalculationFactory
+    from aiida.engine import run_get_node
+
+    if not network_code:
+        from aiida_zeopp import tests
+        network_code = tests.get_code(entry_point='zeopp.network')
+
+    # Prepare input parameters
+    NetworkParameters = DataFactory('zeopp.parameters')
+    # For allowed keys, print(NetworkParameters.schema)
+    parameters = NetworkParameters(
+        dict={
+            'ha': 'DEF',  #just for speed; use 'DEF' for prodution!
+            'psd': [10., 10., 1000],  #compute pore size distribution
+        })
+
+    CifData = DataFactory('cif')
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    structure = CifData(file=os.path.join(this_dir, 'HKUST-1.cif'))
+
+    # set up calculation
+    inputs = {
+        'code': network_code,
+        'parameters': parameters,
+        'structure': structure,
+        'metadata': {
+            'options': {
+                'max_wallclock_seconds': 1 * 60,
+            },
+            'label': 'aiida_zeopp example calculation',
+            'description': 'Compute PSD for a very big probe',
+        },
+    }
+
+    NetworkCalculation = CalculationFactory('zeopp.network')
+    print(
+        'Running NetworkCalculation: computing PSD with all zero/nan values...'
+    )
+    result, node = run_get_node(NetworkCalculation,
+                                **inputs)  # or use aiida.engine.submit
+
+    print('NetworkCalculation<{}> terminated.'.format(node.pk))
+
+    print('\nComputed output_parameters {}\n'.format(
+        str(result['output_parameters'])))
+
+
+@click.command()
+@cmdline.utils.decorators.with_dbenv()
+@cmdline.params.options.CODE()
+def cli(code):
+    """Run example.
+
+    Example usage: $ ./example_03.py --code network@localhost
+
+    Alternative (creates network@localhost-test code): $ ./example_03.py
+
+    Help: $ ./example_03.py --help
+    """
+    test_submit(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Fixed the problem of `nan` values in PSD (pore size distribution) for nonporous structures. 
These `nan` values of the `cumulative` and `derivative` columns are converted to zero.

I included two more examples:
- `example_02` computes the PLD in HKUST-1 with a few sample points
- `example_03` does the same for a big probe radius of 10 Angs, for which HKUST-1 is nonporous and therefore this will go to test the new fix.