### PR TITLE
fix pre-commit failure on travis

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -47,6 +47,7 @@
         ],
         "pre-commit": [
             "pre-commit==2.0.1",
+            "virtualenv<20",
             "yapf==0.28.0",
             "prospector==1.2.0",
             "pylint==2.4.4"

--- a/setup.json
+++ b/setup.json
@@ -46,8 +46,7 @@
             "ase~=3.15"
         ],
         "pre-commit": [
-            "astroid==2.3.3",
-            "pre-commit==1.18.3",
+            "pre-commit==2.0.1",
             "yapf==0.28.0",
             "prospector==1.2.0",
             "pylint==2.4.4"


### PR DESCRIPTION
It seems like virtualenv 20 (needed for `pre-commit`) requires six >= 1.12, but on travis [this is not being installed](https://travis-ci.org/ltalirz/aiida-zeopp/jobs/649566989#L1134).
